### PR TITLE
AudioSearchParams.SearchOwn MethodParamAttribute.Name fix

### DIFF
--- a/ModernDev.InTouch.Shared/API/MethodsParams/AudioSearchParams.cs
+++ b/ModernDev.InTouch.Shared/API/MethodsParams/AudioSearchParams.cs
@@ -53,7 +53,7 @@ namespace ModernDev.InTouch
         /// <summary>
         /// True - to search only user's audio files; False - to exclude user's audio files from search results.
         /// </summary>
-        [MethodParam(Name = "search_down")]
+        [MethodParam(Name = "search_own")]
         public bool SearchOwn { get; set; }
 
         /// <summary>


### PR DESCRIPTION
An incorrect value is set for **AudioSearchParams.SearchOwn** **MethodParamAttribute.Name**. Expected value is **search_own**.