### PR TITLE
Fixed method mask in InTouch.Request<T>

### DIFF
--- a/ModernDev.InTouch.Shared/InTouch.cs
+++ b/ModernDev.InTouch.Shared/InTouch.cs
@@ -509,7 +509,7 @@ namespace ModernDev.InTouch
 
             CacheReqData(methodName, normalizedParams, isOpenMethod, path);
 
-            var json = await Post($"method/{methodName}.json", normalizedParams);
+            var json = await Post($"method/{methodName}", normalizedParams);
 
             return await Task.Run(() => ParseJsonReponse<T>(json, path));
         }


### PR DESCRIPTION
Hello!
Part ".json" in InTouch.Request<T> is useless. Also, this line affects to the deserialization of ResponseError type (RequestParams["method"] == %methodName%.json, and SendCaptcha<T> is never works).