### PR TITLE
Разрешить сессии иметь нулевую длительность

### DIFF
--- a/ModernDev.InTouch.Shared/API/APISession.cs
+++ b/ModernDev.InTouch.Shared/API/APISession.cs
@@ -33,11 +33,18 @@ namespace ModernDev.InTouch
         {
             AccessToken = accessToken;
             UserId = userId;
-            Duration = TimeSpan.FromSeconds(expires);
 
             _sessionStoredDateTime = DateTime.Now;
-
-            InitTimer();
+            
+            if (expires != 0)
+            {
+                Duration = TimeSpan.FromSeconds(expires);
+                InitTimer();
+            }
+            else
+            {
+                Duration = TimeSpan.MaxValue;
+            }
         }
 
 #endregion

--- a/ModernDev.InTouch.Shared/InTouch.cs
+++ b/ModernDev.InTouch.Shared/InTouch.cs
@@ -458,9 +458,9 @@ namespace ModernDev.InTouch
                 throw new ArgumentException("The value cannot be less than or equal to zero.", nameof(userId));
             }
 
-            if (sessionDuration <= 0)
+            if (sessionDuration < 0)
             {
-                throw new ArgumentException("The value cannot be less than or equal to zero.", nameof(sessionDuration));
+                throw new ArgumentException("The value cannot be less than zero.", nameof(sessionDuration));
             }
 
             SetSessionData(new APISession(accessToken, userId, sessionDuration));


### PR DESCRIPTION
VK API возвращает нулевую длительность если запрошено право Offline