### PR TITLE
APIVersion: type changed to string

### DIFF
--- a/ModernDev.InTouch.Shared/InTouch.cs
+++ b/ModernDev.InTouch.Shared/InTouch.cs
@@ -61,7 +61,7 @@ namespace ModernDev.InTouch
         /// <summary>
         /// The used API version.
         /// </summary>
-        public const double APIVersion = 5.52;
+        public const string APIVersion = "5.52";
 
         /// <summary>
         /// Determines the language for the data to be displayed on.


### PR DESCRIPTION
Hello!
Don't use **double** for APIVersion, because ToString() method (e.g. in Russian system localization) returns **"5,52"** while expected **"5.52"**. VK reacts incorrectly to a comma in version and returns incorrect results. Use string for this.